### PR TITLE
Updated operator = implementation to fix crash.

### DIFF
--- a/vector.hpp
+++ b/vector.hpp
@@ -201,6 +201,7 @@ namespace lni {
 		for (i = 0; i < other.vec_sz; ++i)
 			arr[i] = other.arr[i];
 		vec_sz = other.vec_sz;
+		return *this;
 	}
 
 	template <typename T>
@@ -213,6 +214,7 @@ namespace lni {
 		for (i = 0; i < other.vec_sz; ++i)
 			arr[i] = std::move(other.arr[i]);
 		vec_sz = other.vec_sz;
+		return *this;
 	}
 
 	template <typename T>
@@ -224,6 +226,7 @@ namespace lni {
 		vec_sz = 0;
 		for (auto &item: lst)
 			arr[vec_sz++] = item;
+		return *this;
 	}
 
 	template <typename T>


### PR DESCRIPTION
The following was previously causing a warning at compile time and a crash at return time because the return value wasn't specified in operator = implementations.

vector<char> v;
v = {1, 2, 3};